### PR TITLE
feat(dashboard): Dashboard UI and YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+.next/
+dist/
+out/
+coverage/
+tsconfig.tsbuildinfo
+/*.log
+.env
+.env.local
+.env.*.local

--- a/ai/tabs/dashboard.yaml
+++ b/ai/tabs/dashboard.yaml
@@ -1,0 +1,187 @@
+# ai/tabs/dashboard.yaml
+intent: dashboard
+enabled: true
+label: "Dashboard"
+description: >
+  Default opening tab. Returns top-level KPIs, snapshot headline + alert badges,
+  3–4 concise AI insights, upcoming reminders, and a short summary footer.
+  Also supports sub-actions for quick forecast, advisor Q&A, and reminder updates.
+
+input_schema:
+  type: object
+  properties:
+    action:
+      type: string
+      enum: [load, quick_forecast, ask_advisor, update_reminder]
+      description: |
+        load: return dashboard payload
+        quick_forecast: run 30/60/90 day cash projection
+        ask_advisor: answer a short business question
+        update_reminder: change reminder state
+    horizon_days:
+      type: integer
+      description: "Used when action=quick_forecast"
+    question:
+      type: string
+      description: "Used when action=ask_advisor"
+    id:
+      type: string
+      description: "Reminder id when action=update_reminder"
+    op:
+      type: string
+      enum: [complete, snooze, delegate]
+      description: "Operation for reminder update"
+  required: [action]
+  additionalProperties: true
+
+output_schema:
+  oneOf:
+    - type: object
+      title: DashboardPayload
+      properties:
+        kpis:
+          type: object
+          properties:
+            revenue_mtd:  { $ref: "#/definitions/KPI" }
+            net_profit_margin:
+              allOf:
+                - $ref: "#/definitions/KPI"
+                - type: object
+                  properties:
+                    margin_pct: { type: number }
+            cashflow_mtd:  { $ref: "#/definitions/KPI" }
+            runway_months: { $ref: "#/definitions/KPI" }
+            ai_health_score: { $ref: "#/definitions/KPI" }
+        snapshot:
+          type: object
+          properties:
+            headline: { type: string }
+            alerts:
+              type: array
+              items:
+                type: object
+                properties:
+                  kind: { type: string, enum: [red, yellow, green] }
+                  text: { type: string }
+        insights:
+          type: array
+          items: { type: object, properties: { text: { type: string } }, required: [text] }
+        reminders:
+          type: array
+          items:
+            type: object
+            properties:
+              id: { type: string }
+              text: { type: string }
+              due: { type: string }
+              severity: { type: string, enum: [low, med, high] }
+              status: { type: string, enum: [open, done, snoozed] }
+            required: [id, text]
+        summary: { type: string }
+      required: [kpis, insights]
+    - type: object
+      title: AdvisorResponse
+      properties:
+        advisor_reply: { type: string }
+      required: [advisor_reply]
+    - type: object
+      title: Ack
+      properties:
+        ok: { type: boolean }
+      required: [ok]
+
+definitions:
+  KPI:
+    type: object
+    properties:
+      label: { type: string }
+      value:  { type: number }
+      unit:   { type: string }
+      trend_pct: { type: number }
+      href: { type: string }
+    required: [label, value]
+
+prompt:
+  system: |
+    You are LightSignal’s Orchestrator focused on producing a single JSON object that matches the output_schema.
+    IMPORTANT:
+    - Never include extra keys.
+    - Use short, plain language (no fluff).
+    - If data is missing, estimate with clearly labeled rationale (e.g., use last-12-months avg) and set trend_pct conservatively.
+    - For runway, months = max(0, floor(cash_on_hand / monthly_burn)).
+    - AI Health Score reflects data completeness + forecast confidence (0–100).
+    - Alerts:
+        red: runway < 3 months
+        yellow: spending spike detected
+        green: ahead of target
+    - Insight bullets must be actionable and concrete (<= 20 words).
+
+  user_template: |
+    Company ID: {{company_id}}
+    Action: {{action}}
+    Horizon Days: {{horizon_days}}
+    Question: {{question}}
+    Reminder Update: id={{id}} op={{op}}
+
+  fewshot:
+    - role: user
+      content: |
+        Company ID: demo
+        Action: load
+    - role: assistant
+      content: |
+        {
+          "kpis": {
+            "revenue_mtd":        { "label": "Revenue (MTD)", "value": 128000, "unit": "USD", "trend_pct": 7.2, "href": "/overview" },
+            "net_profit_margin":  { "label": "Net Profit / Margin %", "value": 35840, "unit": "USD", "trend_pct": 2.3, "margin_pct": 28.0, "href": "/overview" },
+            "cashflow_mtd":       { "label": "Cash Flow (MTD)", "value": 9100, "unit": "USD", "trend_pct": -3.1, "href": "/overview" },
+            "runway_months":      { "label": "Runway (Months)", "value": 5.0, "trend_pct": 0.0, "href": "/overview" },
+            "ai_health_score":    { "label": "AI Health Score", "value": 82, "unit": "/100", "trend_pct": 1.0, "href": "/overview" }
+          },
+          "snapshot": {
+            "headline": "Revenue up 7.2% vs last month · Expenses flat · Profit margin improved to 28%",
+            "alerts": [
+              { "kind": "green",  "text": "Ahead of target" }
+            ]
+          },
+          "insights": [
+            { "text": "Profit margin improved, but cash conversion slowed — accelerate invoice collection." },
+            { "text": "Labor costs trending 11% above peers." },
+            { "text": "Increase marketing by ~5% to sustain growth." }
+          ],
+          "reminders": [
+            { "id": "tax-qtr",   "text": "Quarterly tax payment due", "due": "in 6 days", "severity": "med", "status": "open" },
+            { "id": "insurance", "text": "Renew business insurance",  "due": "next week", "severity": "low", "status": "open" },
+            { "id": "payroll",   "text": "Payroll approval pending",  "due": "tomorrow",  "severity": "med", "status": "open" },
+            { "id": "invoices",  "text": "Follow up on 3 overdue invoices", "due": "today", "severity": "high", "status": "open" }
+          ],
+          "summary": "Cash healthy · Margins strong · No critical risks detected."
+        }
+
+    - role: user
+      content: |
+        Company ID: demo
+        Action: ask_advisor
+        Question: Can I afford to hire someone next month?
+    - role: assistant
+      content: |
+        { "advisor_reply": "Yes, if net new monthly expense <= $6k and runway stays >= 4 months after hire." }
+
+    - role: user
+      content: |
+        Company ID: demo
+        Action: quick_forecast
+        Horizon Days: 60
+    - role: assistant
+      content: |
+        { "ok": true }
+
+    - role: user
+      content: |
+        Company ID: demo
+        Action: update_reminder
+        id: tax-qtr
+        op: complete
+    - role: assistant
+      content: |
+        { "ok": true }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,232 @@
-// app/page.tsx
-import { redirect } from "next/navigation";
+"use client";
 
-export default function Home() {
-  // Always land on Overview
-  redirect("/overview");
+import { useEffect, useState } from "react";
+// Use RELATIVE import so it works without alias config:
+import { callIntent } from "../lib/api";
+
+type KPI = {
+  label: string;
+  value: number | string;
+  unit?: string;
+  trend_pct?: number;  // positive = up, negative = down
+  href?: string;       // click-through to /overview
+};
+
+type Insight = { text: string };
+type Reminder = {
+  id: string;
+  text: string;
+  due?: string;
+  severity?: "low" | "med" | "high";
+  status?: "open" | "done" | "snoozed";
+};
+
+type DashboardData = {
+  kpis: {
+    revenue_mtd?: KPI;
+    net_profit_margin?: KPI & { margin_pct?: number };
+    cashflow_mtd?: KPI;
+    runway_months?: KPI;
+    ai_health_score?: KPI;
+  };
+  snapshot?: {
+    headline?: string;         // "Revenue up 7.2% vs last month · ..."
+    alerts?: Array<{ kind: "red" | "yellow" | "green"; text: string }>;
+  };
+  insights?: Insight[];
+  reminders?: Reminder[];
+  summary?: string;            // footer strip
+};
+
+const COMPANY_ID = "demo";
+
+function Trend({ pct }: { pct?: number }) {
+  if (pct === undefined || pct === null) return null;
+  const up = pct >= 0;
+  const arrow = up ? "▲" : "▼";
+  const color = up ? "text-emerald-600" : "text-rose-600";
+  const sign = up ? "+" : "";
+  return <span className={`ml-2 text-xs ${color}`}>{arrow} {sign}{pct.toFixed(1)}%</span>;
 }
+
+function Card({ kpi }: { kpi?: Partial<KPI> }) {
+  if (!kpi) return null;
+  const label = kpi.label ?? "—";
+  const value = kpi.value ?? "—";
+  const unit = kpi.unit ? ` ${kpi.unit}` : "";
+  const body = (
+    <div className="p-4 rounded-xl border bg-white hover:shadow-sm transition">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="mt-1 text-2xl font-semibold">
+        {value}{unit} <Trend pct={kpi.trend_pct} />
+      </div>
+      <div className="mt-2 text-xs text-gray-400">Click for details</div>
+    </div>
+  );
+  if (kpi.href) {
+    return <a href={kpi.href} title="Open in Financial Overview">{body}</a>;
+  }
+  return body;
+}
+
+export default function Dashboard() {
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [advisorQ, setAdvisorQ] = useState("");
+  const [advisorA, setAdvisorA] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const resp = await callIntent("dashboard", { action: "load" }, COMPANY_ID);
+      const result = (resp && (resp.result ?? resp)) as DashboardData;
+      setData(result);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { load(); }, []);
+
+  async function runQuickForecast(days: number) {
+    setLoading(true);
+    try {
+      await callIntent("dashboard", { action: "quick_forecast", horizon_days: days }, COMPANY_ID);
+      alert(`Quick forecast generated for ${days} days (check Financial Overview).`);
+    } catch (e: any) {
+      alert(e?.message ?? "Forecast failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function askAdvisor() {
+    if (!advisorQ.trim()) return;
+    setLoading(true);
+    setAdvisorA(null);
+    try {
+      const resp = await callIntent("dashboard", { action: "ask_advisor", question: advisorQ }, COMPANY_ID);
+      const result = (resp && (resp.result ?? resp)) as any;
+      setAdvisorA(result?.advisor_reply ?? "No answer returned.");
+      setAdvisorQ("");
+    } catch {
+      setAdvisorA("Sorry — advisor failed. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function updateReminder(id: string, op: "complete" | "snooze" | "delegate") {
+    setLoading(true);
+    try {
+      await callIntent("dashboard", { action: "update_reminder", id, op }, COMPANY_ID);
+      await load();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const k = data?.kpis ?? {};
+  const snapshot = data?.snapshot;
+  const insights = data?.insights ?? [];
+  const reminders = data?.reminders ?? [];
+  const summary = data?.summary ?? "Cash healthy · Margins strong · No critical risks detected.";
+
+  return (
+    <main className="p-6 space-y-6">
+      {/* KPI row */}
+      <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        <Card kpi={{ ...(k.revenue_mtd ?? {}), href: "/overview" }} />
+        <Card kpi={{ ...(k.net_profit_margin ?? {}), href: "/overview" }} />
+        <Card kpi={{ ...(k.cashflow_mtd ?? {}), href: "/overview" }} />
+        <Card kpi={{ ...(k.runway_months ?? {}), href: "/overview" }} />
+        <Card kpi={{ ...(k.ai_health_score ?? {}), href: "/overview" }} />
+      </section>
+
+      {/* Snapshot + alerts */}
+      <section className="space-y-3">
+        <div className="text-sm text-gray-600">
+          <strong>At-a-Glance:</strong> {snapshot?.headline ?? "—"}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {snapshot?.alerts?.map((a, i) => {
+            const chip =
+              a.kind === "red" ? "bg-rose-50 text-rose-700 border border-rose-200" :
+              a.kind === "yellow" ? "bg-amber-50 text-amber-700 border border-amber-200" :
+              "bg-emerald-50 text-emerald-700 border border-emerald-200";
+            return (
+              <span key={i} className={`px-2 py-1 text-xs rounded-full ${chip}`}>{a.text}</span>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* AI Insights */}
+      <section className="p-4 border rounded-xl bg-white">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold">AI Business Insights</h2>
+          <a className="text-sm text-blue-600 hover:underline" href="/overview">Explore more →</a>
+        </div>
+        <ul className="list-disc ml-5 mt-2 space-y-1 text-gray-700">
+          {insights.length === 0 && <li>No insights yet.</li>}
+          {insights.map((it, i) => <li key={i}>{it.text}</li>)}
+        </ul>
+      </section>
+
+      {/* Quick Actions */}
+      <section className="p-4 border rounded-xl bg-white space-y-3">
+        <h2 className="text-base font-semibold">Quick Actions</h2>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={() => runQuickForecast(30)} className="px-3 py-2 rounded-lg border hover:bg-gray-50">Run 30-day Forecast</button>
+          <button onClick={() => runQuickForecast(60)} className="px-3 py-2 rounded-lg border hover:bg-gray-50">Run 60-day Forecast</button>
+          <button onClick={() => runQuickForecast(90)} className="px-3 py-2 rounded-lg border hover:bg-gray-50">Run 90-day Forecast</button>
+          <a href="/overview" className="px-3 py-2 rounded-lg border hover:bg-gray-50">Add Expense/Revenue</a>
+          <a href="/overview" className="px-3 py-2 rounded-lg border hover:bg-gray-50">View Full Financial Overview</a>
+        </div>
+        <div className="mt-2 flex gap-2">
+          <input
+            value={advisorQ}
+            onChange={(e) => setAdvisorQ(e.target.value)}
+            placeholder='Ask AI Advisor (e.g., "Can I afford to hire next month?")'
+            className="flex-1 px-3 py-2 border rounded-lg"
+          />
+          <button onClick={askAdvisor} className="px-3 py-2 rounded-lg bg-black text-white">Ask</button>
+        </div>
+        {advisorA && <div className="text-sm text-gray-700 mt-2">AI Advisor: {advisorA}</div>}
+      </section>
+
+      {/* Reminders */}
+      <section className="p-4 border rounded-xl bg-white">
+        <h2 className="text-base font-semibold mb-2">Upcoming Reminders</h2>
+        {reminders.length === 0 && <div className="text-sm text-gray-500">No reminders.</div>}
+        <ul className="space-y-2">
+          {reminders.map((r) => (
+            <li key={r.id} className="flex items-center justify-between border rounded-lg p-2">
+              <div>
+                <div className="text-sm">{r.text}</div>
+                {r.due && <div className="text-xs text-gray-500">Due: {r.due}</div>}
+              </div>
+              <div className="flex gap-2">
+                <button onClick={() => updateReminder(r.id, "snooze")} className="text-xs px-2 py-1 border rounded-lg">Snooze</button>
+                <button onClick={() => updateReminder(r.id, "complete")} className="text-xs px-2 py-1 border rounded-lg">Complete</button>
+                <button onClick={() => updateReminder(r.id, "delegate")} className="text-xs px-2 py-1 border rounded-lg">Delegate</button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Summary strip */}
+      <footer className="sticky bottom-3">
+        <div className="text-xs text-gray-600 px-3 py-2 border rounded-full inline-block bg-white">
+          {summary}
+        </div>
+      </footer>
+
+      {loading && (
+        <div className="fixed inset-0 bg-black/5 pointer-events-none" aria-hidden />
+      )}
+    </main>
+  );
+}
+


### PR DESCRIPTION
Implements Dashboard tab per spec. Backend-first via NEXT_PUBLIC_API_URL with safe stub fallback; hooks up quick forecast, AI advisor prompt, reminder updates. Adds ai/tabs/dashboard.yaml for backend reference.